### PR TITLE
update to layout of video on smaller screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -32,3 +32,14 @@ body {
   min-height: 100%;
   z-index: -1;
 }
+
+/* Media query for smaller screens */
+@media (max-width: 767px) {
+  .video-container video {
+    /* offset att building to the left */
+    object-position: 30% top;
+
+    /* centers the att building */
+    /* object-position: 22% top; */
+  }
+}

--- a/app/hamburger.js
+++ b/app/hamburger.js
@@ -87,11 +87,11 @@ export default function Hamburger() {
                                 About
                             </li>
                         </Link>
-                        <Link href="testimonial">
+                        <Link href="work">
                             <li
                                 onClick={() => setNavbarOpen(false)}
                                 className="py-4 cursor-pointer">
-                                Testimonial
+                                Work
                             </li>
                         </Link>
                         <Link href="contact">

--- a/app/layout.js
+++ b/app/layout.js
@@ -13,7 +13,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className={inter.className + ' flex flex-col min-h-screen'}>
         <NavBar />
         {children}
         <Footer />

--- a/app/navbar.js
+++ b/app/navbar.js
@@ -6,7 +6,7 @@ export default function NavBar() {
 
     return (
         <>
-            <div className="flex flex-row justify-end md:justify-between border-b md:border-0">
+            <div className="flex flex-row justify-end md:justify-between border-b md:border-0 bg-slate-500 bg-opacity-50 md:bg-transparent">
                 <div className="hidden md:block w-1/4 md:m-2">
                     <div className="flex justify-center">
                         <Image

--- a/app/page.js
+++ b/app/page.js
@@ -2,17 +2,19 @@ import Image from 'next/image'
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between">
+    <main className="flex min-h-screen flex-col items-center justify-between overflow-hidden">
 
       {/* Nashville Video */}
-      <video
-        id='fullscreenVideo'
-        autoPlay
-        muted
-        className="absolute w-screen h-screen object-cover"
-      >
-        <source src="https://res.cloudinary.com/dp04hh5pz/video/upload/v1692109540/OpClean/Vidoes/Nashville.Video_mtqhuc.mp4" type="video/mp4" />
-      </video>
+      <div class="video-container">
+        <video
+          id='fullscreenVideo'
+          autoPlay
+          muted
+          className="w-screen h-screen object-cover flex-1"
+        >
+          <source src="https://res.cloudinary.com/dp04hh5pz/video/upload/v1692109540/OpClean/Vidoes/Nashville.Video_mtqhuc.mp4" type="video/mp4" />
+        </video>
+      </div>
 
       <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">
         <div className="fixed md:hidden bottom-0 left-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white dark:from-black dark:via-black lg:static lg:h-auto lg:w-auto lg:bg-none">


### PR DESCRIPTION
new `media query` set for smaller screens
```py
/* Media query for smaller screens */
@media (max-width: 767px) {
  .video-container video {
    /* offset att building to the left */
    object-position: 30% top;

    /* centers the att building */
    /* object-position: 22% top; */
  }
}
```
Wrapped video element in `div` to target with css 
```py
 <div class="video-container">
        <video
          id='fullscreenVideo'
          autoPlay
          muted
          className="w-screen h-screen object-cover flex-1"
        >
          <source src="https://res.cloudinary.com/dp04hh5pz/video/upload/v1692109540/OpClean/Vidoes/Nashville.Video_mtqhuc.mp4" type="video/mp4" />
        </video>
      </div>
```